### PR TITLE
Fix single field update and excess fields set

### DIFF
--- a/asyncorm/manager/model_manager.py
+++ b/asyncorm/manager/model_manager.py
@@ -28,14 +28,14 @@ class ModelManager(Queryset):
         # performs the database save
         fields, field_data = [], []
 
-        for k, data in instanced_model.data.items():
-            f_class = getattr(instanced_model.__class__, k)
-
-            field_name = f_class.db_column or k
+        field_names_mapping = instanced_model.__class__.orm_attr_names()
+        for column_name, data in instanced_model.data.items():
+            field_name = field_names_mapping[column_name]
+            f_class = getattr(instanced_model.__class__, field_name)
 
             data = f_class.sanitize_data(data)
 
-            fields.append(field_name)
+            fields.append(column_name)
             field_data.append(data)
 
         for field in instanced_model.fields.keys():

--- a/asyncorm/models/models.py
+++ b/asyncorm/models/models.py
@@ -298,7 +298,12 @@ class Model(BaseModel):
                             k = orm
                             break
                 # get the recomposed value
-                field_class = getattr(self.__class__, k)
+                field_class = getattr(self.__class__, k, None)
+
+                # skip, if we were got field not declared in model
+                if field_class is None:
+                    continue
+
                 v = field_class.recompose(v)
 
                 if field_class in [ForeignKey, ManyToManyField]:

--- a/asyncorm/models/models.py
+++ b/asyncorm/models/models.py
@@ -171,6 +171,10 @@ class BaseModel(object, metaclass=ModelMeta):
         return d
 
     @classmethod
+    def orm_attr_names(cls):
+        return {v: k for k, v in cls.attr_names.items()}
+
+    @classmethod
     def get_fields(cls):
         fields = {}
 
@@ -299,11 +303,8 @@ class Model(BaseModel):
                             break
                 # get the recomposed value
                 field_class = getattr(self.__class__, k, None)
-
-                # skip, if we were got field not declared in model
                 if field_class is None:
                     continue
-
                 v = field_class.recompose(v)
 
                 if field_class in [ForeignKey, ManyToManyField]:


### PR DESCRIPTION
1) If we have table with fields, which not represent in Model, we get AttributeError, because fields is does not exists in Model. We can use .only() for correct retrieve instance, but save is impossible - 0120f09 
2) if we set only one field and try to update model,  we get error from Postgres, because syntax with () is unsupported for single-field update - 52a3168 
3) if we set db_column, we get AttributeError after instance.save(), because we try to get field_class with db_column, but we need use orm field name - 6a0bc48 