### PR TITLE
Fix default values and filter by empty list

### DIFF
--- a/asyncorm/exceptions.py
+++ b/asyncorm/exceptions.py
@@ -88,3 +88,8 @@ class AsyncOrmAppError(AsyncormException):
     """Raised when there are class App or configuration errors detected."""
 
     pass
+
+
+class AsyncOrmEmptyResult(AsyncormException):
+    """Raised when query can't match anything"""
+    pass

--- a/asyncorm/manager/model_manager.py
+++ b/asyncorm/manager/model_manager.py
@@ -45,7 +45,7 @@ class ModelManager(Queryset):
                 field_name = f_class.db_column or field
                 data = getattr(instanced_model, field)
                 field_has_default = hasattr(instanced_model.fields[field], "default")
-                default_not_none = instanced_model.fields[field].default is not None
+                default_not_none = instanced_model.fields[field].default is not None if field_has_default else False
                 not_auto_field = not isinstance(f_class, AutoField)
                 if data is None and field_has_default and default_not_none and not_auto_field:
                     data = instanced_model.fields[field].default

--- a/asyncorm/models/field.py
+++ b/asyncorm/models/field.py
@@ -1,6 +1,7 @@
 from asyncorm.exceptions import AsyncOrmFieldError
 
 DATE_FIELDS = ["DateField"]
+UUID_FIELDS = ["UUIDField"]
 
 KWARGS_TYPES = {
     "auto_now": bool,
@@ -54,6 +55,8 @@ class Field(object):
                     pass
                 else:
                     self.choices = {k: v for k, v in kwargs.get(kw)}
+            elif kw == "default" and self.field_type in [*DATE_FIELDS, *UUID_FIELDS]:
+                delattr(self, "default")
 
     def creation_query(self):
         """Create the field's database creation query.
@@ -116,10 +119,11 @@ class Field(object):
             * When the value provided is not in the field choices.
             * When the value provided is not in the self.internal_type
         """
-        if value is None and not self.null:
+        auto_date = self.field_type in DATE_FIELDS and self.auto_now
+        if value is None and not self.null and not auto_date:
             raise AsyncOrmFieldError("null value in NOT NULLABLE field")
 
-        if hasattr(self, "choices") and self.choices is not None:
+        if hasattr(self, "choices") and self.choices is not None and value is not None:
             if value not in self.choices.keys():
                 raise AsyncOrmFieldError('"{}" not in field choices'.format(value))
 

--- a/asyncorm/models/field.py
+++ b/asyncorm/models/field.py
@@ -55,7 +55,7 @@ class Field(object):
                     pass
                 else:
                     self.choices = {k: v for k, v in kwargs.get(kw)}
-            elif kw == "default" and self.field_type in [*DATE_FIELDS, *UUID_FIELDS]:
+            elif kw == "default" and kwargs[kw] is None and self.field_type in [*DATE_FIELDS, *UUID_FIELDS]:
                 delattr(self, "default")
 
     def creation_query(self):

--- a/asyncorm/models/field.py
+++ b/asyncorm/models/field.py
@@ -119,8 +119,7 @@ class Field(object):
             * When the value provided is not in the field choices.
             * When the value provided is not in the self.internal_type
         """
-        auto_date = self.field_type in DATE_FIELDS and self.auto_now
-        if value is None and not self.null and not auto_date:
+        if value is None and not self.null:
             raise AsyncOrmFieldError("null value in NOT NULLABLE field")
 
         if hasattr(self, "choices") and self.choices is not None and value is not None:
@@ -138,6 +137,8 @@ class Field(object):
 
     def sanitize_data(self, value):
         """Sanitize the query before send to database."""
+        if value is None and self.null:
+            return
         self.validate(value)
         return value
 

--- a/asyncorm/models/fields.py
+++ b/asyncorm/models/fields.py
@@ -56,11 +56,11 @@ class CharField(Field):
 
     def sanitize_data(self, value):
         value = super().sanitize_data(value)
-        if len(value) > self.max_length:
+        if value is not None and len(value) > self.max_length:
             raise AsyncOrmFieldError(
                 'The string entered is bigger than the "max_length" defined ({})'.format(self.max_length)
             )
-        return str(value)
+        return str(value) if value is not None else None
 
 
 class EmailField(CharField):
@@ -68,7 +68,7 @@ class EmailField(CharField):
         super(EmailField, self).validate(value)
         # now validate the emailfield here
         email_regex = r"^[\w][\w0-9_.+-]+@[\w0-9-]+\.[\w0-9-.]+$"
-        if not re.match(email_regex, value):
+        if not (value is None and self.null) and not re.match(email_regex, value):
             raise AsyncOrmFieldError('"{}" not a valid email address'.format(value))
 
 
@@ -299,7 +299,7 @@ class UUIDField(Field):
 
     def sanitize_data(self, value):
         exp = r"^[a-zA-Z0-9\-\b]{36}$"
-        if re.match(exp, value):
+        if value is None and self.null or re.match(exp, value):
             return value
         raise AsyncOrmFieldError("The expression doesn't validate as a correct {}".format(self.__class__.__name__))
 

--- a/asyncorm/models/models.py
+++ b/asyncorm/models/models.py
@@ -150,7 +150,9 @@ class BaseModel(object, metaclass=ModelMeta):
                 d[db] = self__orm
 
                 default = self__orm == class__orm.default
-                if created and default:
+                # if value equal to default we set him with insert,
+                # else we should always represent him
+                if not created and default:
                     d.pop(db)
 
         return d

--- a/tests/app_1/models.py
+++ b/tests/app_1/models.py
@@ -48,5 +48,5 @@ class Book(models.Model):
 class Reader(models.Model):
     name = models.CharField(max_length=15, default="pepito")
     size = models.CharField(choices=SIZE_CHOICES, max_length=2)
-    power = models.CharField(choices=POWER_CHOICES, max_length=2, null=True)
+    power = models.CharField(choices=POWER_CHOICES, max_length=3, null=True)
     weight = models.IntegerField(default=weight)


### PR DESCRIPTION
1. If we try to set instance.field to default value, value must not be skipped - 571a28c;
2. If we try use empty array with "in" lookup we not be get error - 0b29c20;
3. Fix tests (i tried run tests!), all tests passed in 3.6, 3.7, 3.8 python versions - 0d090da.